### PR TITLE
Fix "TypeError: no implicit conversion of Hash into String"

### DIFF
--- a/academia-dl.rb
+++ b/academia-dl.rb
@@ -45,7 +45,8 @@ ARGV.each do |academia_url|
       download_id = download_url.split('/')[-2]
       url = "#{PREFIX}/#{download_id}/#{filename}"
       $stderr.puts "Resolved download URL: #{url}"
-      IO.copy_stream(open(url, OPEN_URI_OPTIONS), filename)
+      stream = URI.open(url, **OPEN_URI_OPTIONS)
+      IO.copy_stream(stream, filename)
       $stderr.puts "Downloaded #{filename}"
     rescue StandardError => e
       $stderr.puts "Error parsing/downloading file for URL #{url}: #{e.inspect}"


### PR DESCRIPTION
Hi! Just discovered this script on mastodon and gave it a go. Thank you so much for this script!

For some reason it didn't like the `open` call on my system, but some slight modification made it work.

Note that I'm a total Ruby n00b, so while this did make it work for me, it may be just chance. I looked here to figure to use `URI.open` and splat the hash into its call: https://ruby-doc.org/stdlib-2.6.3/libdoc/open-uri/rdoc/OpenURI.html